### PR TITLE
Enable no intercept

### DIFF
--- a/src/LinearRegression.jl
+++ b/src/LinearRegression.jl
@@ -84,7 +84,7 @@ function Base.show(io::IO, lr::linRegRes)
     
     println(io, "Coefficients statistics:")
     na = NamedArray(reduce(hcat, all_stats))
-    setnames!(na, encapsulate_string(StatsBase.coefnames(lr.updformula.rhs)), 1 )
+    setnames!(na, encapsulate_string(string.(StatsBase.coefnames(lr.updformula.rhs))), 1 )
     setnames!(na, encapsulate_string(all_stats_name), 2 )
     setdimnames!(na, ("Terms", "Stats"))
     my_namedarray_print(io, na)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -189,11 +189,19 @@ end
 
     used exclusively to handle the function ```StatsBase.coefnames``` which sometime return an array or when there is only one element the element alone. 
 """
-function encapsulate_string(s)
-    if isa(s, String)
-        return [s]
-    end
-    return s
+function encapsulate_string(s::String)
+    return [s]
+end
+
+"""
+    function encapsulate_string(v)
+
+    (internal) Only used to encapsulate a string into an array.
+
+    used exclusively to handle the function ```StatsBase.coefnames``` which sometime return an array or when there is only one element the element alone. 
+"""
+function encapsulate_string(v::Vector{String})
+    return v
 end
 
 import Printf

--- a/test/test_noint.jl
+++ b/test/test_noint.jl
@@ -7,4 +7,6 @@
     @test isapprox(0.9252939081, lrnoint.R2)
     @test isapprox(0.9237997863, lrnoint.ADJR2)
     @test isapprox(160.90768623, lrnoint.AIC)
+
+    # TODO add a test case for multiple linear regression without intercept and the VIF
 end


### PR DESCRIPTION
Enable model without an intercept. 
An intercept is added implicitly, as with GLM.