### PR TITLE
fix branch name

### DIFF
--- a/.github/workflows/generation_docs.yml
+++ b/.github/workflows/generation_docs.yml
@@ -3,7 +3,7 @@ name: Documentation
 on:
   push:
     branches:
-      - master
+      - main
     tags: '*'
   pull_request:
 


### PR DESCRIPTION
This way, the workflow will run when you commit to `main`, and the docs can build then.